### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Compress/Snappy.pm
+++ b/lib/Compress/Snappy.pm
@@ -1,4 +1,4 @@
-module Compress::Snappy;
+unit module Compress::Snappy;
 use v6;
 
 use NativeCall;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
