### PR TITLE
Add optional encoding arg, and some performance improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,6 @@ perl6:
 
 install:
     - sudo apt-get install libsnappy-dev
-    - rakudobrew build-panda
-    - panda installdeps .
+    - rakudobrew build zef
+    - zef install .
+

--- a/README.md
+++ b/README.md
@@ -23,13 +23,15 @@ compression library with an emphasis on speed over compression.
 
 Main compression function. Returns a Buf of compressed data.
 
-## Compress::Snappy::compress(Str $uncompressed) returns Buf
+## Compress::Snappy::compress(Str $uncompressed, Str $encoding = 'utf-8') returns Buf
 
-Convenience function to make a Str to a utf8-encoded Blob and compress that.
+Convenience function to make a Str to an encoded Blob and compress that.
+Encoding defaults to utf-8 if not specified.
 
-## Compress::Snappy::decompress(Blob $compressed) returns Buf
+## Compress::Snappy::decompress(Blob $compressed, Str $encoding)
 
-Decompress provided data to a Buf.
+Decompress provided data to a Buf.  If an optional $encoding is
+specified, will decode the Buf and return a Str instead.
 
 ## Compress::Snappy::validate(Blob $compressed) returns Bool
 

--- a/examples/bench.p6
+++ b/examples/bench.p6
@@ -1,0 +1,19 @@
+#!/usr/bin/env perl6
+
+use v6;
+
+use Compress::Snappy;
+
+my &scompress = &Compress::Snappy::compress;
+my &svalidate = &Compress::Snappy::validate;
+my &sdecompress = &Compress::Snappy::decompress;
+
+sub MAIN(Int $loopcount = 1) {
+    for ^$loopcount {
+	my $buf = scompress("a" x 80000);
+
+	my $valid = svalidate($buf);
+
+	my $decoded = sdecompress($buf);
+    }
+}

--- a/lib/Compress/Snappy.pm
+++ b/lib/Compress/Snappy.pm
@@ -9,38 +9,22 @@ constant SNAPPY_INVALID_INPUT = 1;
 constant SNAPPY_BUFFER_TOO_SMALL = 2;
 
 sub snappy_max_compressed_length(size_t) returns size_t is native(libsnappy) {...}
-sub snappy_compress(CArray[uint8], size_t, CArray[uint8], size_t is rw) returns int32 is native(libsnappy) {...}
+sub snappy_compress(Blob, size_t, CArray[uint8], size_t is rw) returns int32 is native(libsnappy) {...}
 
-sub snappy_uncompressed_length(CArray[uint8], size_t, size_t is rw) returns int32 is native(libsnappy) {...}
-sub snappy_uncompress(CArray[uint8], size_t, CArray[uint8], size_t is rw) returns int32 is native(libsnappy) {...}
+sub snappy_uncompressed_length(Blob, size_t, size_t is rw) returns int32 is native(libsnappy) {...}
+sub snappy_uncompress(Blob, size_t, CArray[uint8], size_t is rw) returns int32 is native(libsnappy) {...}
 
-sub snappy_validate_compressed_buffer(CArray[uint8], size_t) returns int32 is native(libsnappy) {...}
+sub snappy_validate_compressed_buffer(Blob, size_t) returns int32 is native(libsnappy) {...}
 
-# helper functions to hide translations between Perl and C representations
+# helper function to hide translations between Perl and C representations
 sub _zero_array(Int $count) {
 	my $array = CArray[uint8].new();
-	$array[$_] = 0 for ^$count;
+        $array[$count-1] = 0;
 	return $array;
-}
-
-# these two can go away if/when NativeCall learns to translate Blobs to CArrays
-sub _copy_blob_to_array(Blob $blob) {
-	my $array = CArray[uint8].new();
-	$array[$_] = $blob[$_] for ^$blob.bytes;
-	return $array;
-}
-
-sub _int_pointer(Int $value = 0) {
-	# Simulate an int pointer with a CArray
-	my $intpointer = CArray[int].new();
-	$intpointer[0] = $value;
-	return $intpointer;
 }
 
 our sub validate(Blob $blob) returns Bool {
-	my $compressed = _copy_blob_to_array($blob);
-	my $status = snappy_validate_compressed_buffer($compressed, $blob.bytes);
-	return $status == 0;
+        snappy_validate_compressed_buffer($blob, $blob.bytes) == 0;
 }
 
 our proto compress($, |) {*};
@@ -49,16 +33,14 @@ multi compress(Blob $blob) returns Buf {
 
 	# Allocate an int pointer to store the length
 	my $output = _zero_array($max-size);
-	my $input = _copy_blob_to_array($blob);
-	my size_t $blob-size = $blob.bytes;
 
-	my $status = snappy_compress($input, $blob-size, $output, $max-size);
+	my $status = snappy_compress($blob, $blob.bytes, $output, $max-size);
 	if $status {
 		die "snappy_compress internal error: $status";
 	}
 
 	# Copy everything into a Buf
-	return Buf.new: map {$output[$_]}, ^$max-size;
+        Buf.new($output[^$max-size]);
 }
 
 multi compress(Str $str, Str $encoding = 'utf-8') returns Buf {
@@ -68,21 +50,19 @@ multi compress(Str $str, Str $encoding = 'utf-8') returns Buf {
 our sub decompress(Blob $blob, Str $encoding = Str) {
 	# Allocate an int pointer to store the length
 	my size_t $uncompressed-length;
-	my $compressed = _copy_blob_to_array($blob);
-	my size_t $blob-size = $blob.bytes;
 
-	my $status1 = snappy_uncompressed_length($compressed, $blob-size, $uncompressed-length);
+	my $status1 = snappy_uncompressed_length($blob, $blob.bytes, $uncompressed-length);
 	if $status1 {
 		die "snappy_uncompress internal error: $status1";
 	}
 
 	my $uncompressed = _zero_array($uncompressed-length);
-	my $status2 = snappy_uncompress($compressed, $blob.bytes, $uncompressed, $uncompressed-length);
+	my $status2 = snappy_uncompress($blob, $blob.bytes, $uncompressed, $uncompressed-length);
 	if $status2 {
 		die "snappy_uncompress internal error: $status2";
 	}
 
-        my $buf = Buf.new: map {$uncompressed[$_]}, ^$uncompressed-length;
+        my $buf = Buf.new($uncompressed[^$uncompressed-length]);
 
         return $encoding.defined ?? $buf.decode($encoding) !! $buf;
 }

--- a/lib/Compress/Snappy.pm
+++ b/lib/Compress/Snappy.pm
@@ -47,7 +47,7 @@ multi compress(Str $str, Str $encoding = 'utf-8') returns Buf {
 	return compress($str.encode($encoding));
 }
 
-our sub decompress(Blob $blob, Str $encoding = Str) {
+our sub decompress(Blob $blob, Str $encoding?) {
 	# Allocate an int pointer to store the length
 	my size_t $uncompressed-length;
 

--- a/t/encoding.t
+++ b/t/encoding.t
@@ -1,0 +1,23 @@
+use v6;
+
+use Compress::Snappy;
+use Test;
+
+multi roundtrip-test(Str $in, Str $label) {
+	my $compressed = Compress::Snappy::compress($in, 'utf-8');
+	ok Compress::Snappy::validate($compressed), "validate on $label (Str)";
+	my $decompressed = Compress::Snappy::decompress($compressed, 'utf-8');
+	is $decompressed, $in, "roundtrip on $label (Str)";
+}
+
+roundtrip-test '', 'empty string';
+
+roundtrip-test 'Hello, world!', 'short greeting';
+
+roundtrip-test '0' x 1024, '1k of zeroes';
+
+roundtrip-test ([~] 'a' .. 'z') x 100, '100 alphabets';
+
+roundtrip-test '»ö« .oO(æ€!éè)' x 100, '100 strings with unicode characters';
+
+done-testing;


### PR DESCRIPTION
The optional encoding arg (recommended in issue #1) has defaults, so shouldn't change the interface at all for current users.

NativeCall can now pass in Blobs, doing the conversion itself.

It gets considerably faster (my unscientific test of >1 minute before this patch goes to 12 seconds after).
