### PR TITLE
Adds installation instructions for library, modifies .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .*.swp
-lib/.precomp
+.precomp

--- a/README.md
+++ b/README.md
@@ -2,6 +2,15 @@
 
 Compress::Snappy - (de)compress data in Google's Snappy compression format
 
+# INSTALLATION
+
+`libsnappy-dev` or equivalent needs to be installed for this to
+work. Issue 
+
+    sudo apt-get install libsnappy-dev
+    
+or equivalent order in other operatins systems or distros to do so.
+
 # SYNOPSIS
 
 ```perl6


### PR DESCRIPTION
So that it ignores the `.precomp` file anywhere it's found. Goes towards solving ecosystem-unbitrot#264