### PR TITLE
Fix bogus "Cannot locate native library 'libsnappy.so'"

### DIFF
--- a/lib/Compress/Snappy.pm6
+++ b/lib/Compress/Snappy.pm6
@@ -3,7 +3,7 @@ unit module Compress::Snappy;
 
 use NativeCall;
 
-my constant libsnappy = 'snappy';
+my constant libsnappy = 'snappy', v1;
 constant SNAPPY_OK = 0;
 constant SNAPPY_INVALID_INPUT = 1;
 constant SNAPPY_BUFFER_TOO_SMALL = 2;


### PR DESCRIPTION
The Compress::Snappy module couldn't find the snappy library, despite
there being a `/usr/lib64/libsnappy.so.1` and `/usr/lib64/libsnappy.so.1.1.9`
present on my system. Telling NativeCall the expected major version fixes
the issue.

Libraries are expected to retain compatibility within major SO versions,
so if there's ever a `libsnappy.so.2`, `Compress::Snappy` will probably need
adjustments anyway.